### PR TITLE
fix: prevent Netty I/O thread blocking by async channel release via reconnectExecutor

### DIFF
--- a/changes/en-us/2.x.md
+++ b/changes/en-us/2.x.md
@@ -32,6 +32,7 @@ Add changes here for all PR submitted to the 2.x branch.
 - [[#7370](https://github.com/apache/incubator-seata/pull/7370)] fix ISSUE_TEMPLATE not work
 - [[#7397](https://github.com/apache/incubator-seata/pull/7397)] Resolve NullPointer and port binding errors
 - [[#7498](https://github.com/apache/incubator-seata/pull/7498)] fix the class name whitelist check issue in fury deserialization
+- [[#7505](https://github.com/apache/incubator-seata/pull/7505)] prevent Netty I/O thread blocking by async channel release via reconnectExecutor
 
 
 ### optimize:

--- a/changes/zh-cn/2.x.md
+++ b/changes/zh-cn/2.x.md
@@ -31,6 +31,7 @@
 - [[#7370](https://github.com/apache/incubator-seata/pull/7370)] 修复 ISSUE_TEMPLATE 不可用
 - [[#7397](https://github.com/apache/incubator-seata/pull/7397)] 解决空指针和端口绑定错误
 - [[#7498](https://github.com/apache/incubator-seata/pull/7498)] 修复fury反序列化的类名白名单检查问题
+- [[#7505](https://github.com/apache/incubator-seata/pull/7505)] 通过使用 reconnectExecutor 异步释放 channel，防止阻塞 Netty I/O 线程
 
 
 ### optimize:

--- a/core/src/main/java/org/apache/seata/core/rpc/netty/AbstractNettyRemotingClient.java
+++ b/core/src/main/java/org/apache/seata/core/rpc/netty/AbstractNettyRemotingClient.java
@@ -87,6 +87,8 @@ public abstract class AbstractNettyRemotingClient extends AbstractNettyRemoting 
     private static final long SCHEDULE_DELAY_MILLS = 60 * 1000L;
     private static final long SCHEDULE_INTERVAL_MILLS = 10 * 1000L;
     private static final String MERGE_THREAD_PREFIX = "rpcMergeMessageSend";
+    private static final int MAX_RECONNECT_THREAD = 1;
+    private static final String RECONNECT_THREAD_PREFIX = "rpcReconnect";
 
     private final CopyOnWriteArrayList<ChannelEventListener> channelEventListeners = new CopyOnWriteArrayList<>();
 
@@ -110,6 +112,7 @@ public abstract class AbstractNettyRemotingClient extends AbstractNettyRemoting 
     private final NettyClientBootstrap clientBootstrap;
     private final NettyClientChannelManager clientChannelManager;
     private final NettyPoolKey.TransactionRole transactionRole;
+    private ExecutorService reconnectExecutor;
     private ExecutorService mergeSendExecutorService;
     private TransactionMessageHandler transactionMessageHandler;
     protected volatile boolean enableClientBatchSendRequest;
@@ -137,6 +140,13 @@ public abstract class AbstractNettyRemotingClient extends AbstractNettyRemoting 
                     new NamedThreadFactory(getThreadPrefix(), MAX_MERGE_SEND_THREAD));
             mergeSendExecutorService.submit(new MergedSendRunnable());
         }
+        reconnectExecutor = new ThreadPoolExecutor(
+                MAX_RECONNECT_THREAD,
+                MAX_RECONNECT_THREAD,
+                KEEP_ALIVE_TIME,
+                TimeUnit.MILLISECONDS,
+                new LinkedBlockingQueue<>(),
+                new NamedThreadFactory(getReconnectExecutorThreadPrefix(), MAX_RECONNECT_THREAD));
         super.init();
         clientBootstrap.start();
     }
@@ -268,6 +278,9 @@ public abstract class AbstractNettyRemotingClient extends AbstractNettyRemoting 
         if (mergeSendExecutorService != null) {
             mergeSendExecutorService.shutdown();
         }
+        if (reconnectExecutor != null) {
+            reconnectExecutor.shutdown();
+        }
         super.destroy();
     }
 
@@ -334,6 +347,10 @@ public abstract class AbstractNettyRemotingClient extends AbstractNettyRemoting 
 
     private String getThreadPrefix() {
         return AbstractNettyRemotingClient.MERGE_THREAD_PREFIX + THREAD_PREFIX_SPLIT_CHAR + transactionRole.name();
+    }
+
+    private String getReconnectExecutorThreadPrefix() {
+        return AbstractNettyRemotingClient.RECONNECT_THREAD_PREFIX + THREAD_PREFIX_SPLIT_CHAR + transactionRole.name();
     }
 
     /**
@@ -723,7 +740,13 @@ public abstract class AbstractNettyRemotingClient extends AbstractNettyRemoting 
                     FrameworkErrorCode.ExceptionCaught.getErrCode(),
                     NetUtil.toStringAddress(ctx.channel().remoteAddress()) + "connect exception. " + cause.getMessage(),
                     cause);
-            clientChannelManager.releaseChannel(ctx.channel(), getAddressFromChannel(ctx.channel()));
+            reconnectExecutor.execute(() -> {
+                try {
+                    clientChannelManager.releaseChannel(ctx.channel(), getAddressFromChannel(ctx.channel()));
+                } catch (Throwable throwable) {
+                    LOGGER.error("release channel error: {}", throwable.getMessage(), throwable);
+                }
+            });
             if (LOGGER.isInfoEnabled()) {
                 LOGGER.info("remove exception rm channel:{}", ctx.channel());
             }

--- a/core/src/test/java/org/apache/seata/core/rpc/netty/ResourceCleanupTest.java
+++ b/core/src/test/java/org/apache/seata/core/rpc/netty/ResourceCleanupTest.java
@@ -17,6 +17,7 @@
 package org.apache.seata.core.rpc.netty;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelId;
 import org.apache.seata.core.protocol.MergeMessage;
 import org.apache.seata.core.protocol.MergedWarpMessage;
@@ -59,6 +60,7 @@ class ResourceCleanupTest {
     @BeforeEach
     void setUp() throws Exception {
         client = TmNettyRemotingClient.getInstance();
+        client.init();
 
         Field futuresField = AbstractNettyRemoting.class.getDeclaredField("futures");
         futuresField.setAccessible(true);
@@ -141,6 +143,26 @@ class ResourceCleanupTest {
 
         assertDoesNotThrow(() -> client.cleanupResourcesForChannel(null));
         assertTrue(futures.containsKey(1), "Future ID 1 should still exist");
+    }
+
+    @Test
+    void testExceptionCaughtTriggersChannelRelease() throws Exception {
+        AbstractNettyRemotingClient.ClientHandler handler = client.new ClientHandler();
+        ChannelHandlerContext mockCtx = mock(ChannelHandlerContext.class);
+        when(mockCtx.channel()).thenReturn(channel);
+        when(channel.remoteAddress()).thenReturn(new InetSocketAddress("127.0.0.1", 8091));
+        Field channelManagerField = AbstractNettyRemotingClient.class.getDeclaredField("clientChannelManager");
+        channelManagerField.setAccessible(true);
+        NettyClientChannelManager originalManager = (NettyClientChannelManager) channelManagerField.get(client);
+
+        NettyClientChannelManager spyManager = spy(originalManager);
+        channelManagerField.set(client, spyManager);
+
+        handler.exceptionCaught(mockCtx, new IllegalArgumentException("test"));
+
+        Thread.sleep(500);
+        verify(spyManager).releaseChannel(eq(channel), anyString());
+        channelManagerField.set(client, originalManager);
     }
 
     private RpcMessage createRpcMessage(int id) {


### PR DESCRIPTION
<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
    The ASF licenses this file to You under the Apache License, Version 2.0
    (the "License"); you may not use this file except in compliance with
    the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0
    
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-->
<!-- Please make sure you have read and understood the contributing guidelines -->

- [ ] I have registered the PR [changes](../changes).

### Ⅰ. Describe what this PR did

Fixes a potential Netty I/O thread blocking issue by executing `releaseChannel()` asynchronously via a dedicated `reconnectExecutor` thread pool.

Also ensures proper shutdown of `reconnectExecutor` to avoid thread leaks.


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

fixes #7497


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
- Naming conventions (`rpcReconnectExecutor`) aligned with existing merge thread patterns.
- `reconnectExecutor` is now managed with proper init and destroy lifecycle hooks.
